### PR TITLE
Simplify IntoInitializer

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -257,10 +257,10 @@ struct SubSubClass {
 #[pymethods]
 impl SubSubClass {
    #[new]
-   fn new() -> impl IntoInitializer<Self> {
-       Ok(SubClass::new()
-           .into_initializer()?
-           .add_subclass(SubSubClass{val3: 20}))
+   fn new() -> PyClassInitializer<Self> {
+       SubClass::new()
+           .into_initializer()
+           .add_subclass(SubSubClass{val3: 20})
    }
 
    fn method3(self_: &PyClassShell<Self>) -> PyResult<usize> {

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -154,7 +154,7 @@ pub fn impl_wrap_new(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
     let body = impl_arg_params_(
         spec,
         cb,
-        quote! { pyo3::pyclass_init::IntoInitializer::into_initializer },
+        quote! { pyo3::derive_utils::IntoPyNewResult::into_pynew_result },
     );
 
     quote! {
@@ -174,7 +174,7 @@ pub fn impl_wrap_new(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
 
             #body
 
-            match _result.and_then(|init| init.create_shell(_py)) {
+            match _result.and_then(|init| init.into_initializer().create_shell(_py)) {
                 Ok(slf) => slf as _,
                 Err(e) => e.restore_and_null(_py),
             }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -42,7 +42,7 @@ impl<T> Py<T> {
         <T::BaseType as PyTypeInfo>::ConcreteLayout:
             crate::type_object::PyObjectSizedLayout<T::BaseType>,
     {
-        let initializer = value.into_initializer()?;
+        let initializer = value.into_initializer();
         let obj = unsafe { initializer.create_shell(py)? };
         let ob = unsafe { Py::from_owned_ptr(obj as _) };
         Ok(ob)

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -136,7 +136,7 @@ impl<T: PyClass> PyClassShell<T> {
             crate::type_object::PyObjectSizedLayout<T::BaseType>,
     {
         unsafe {
-            let initializer = value.into_initializer()?;
+            let initializer = value.into_initializer();
             let self_ = initializer.create_shell(py)?;
             FromPyPointer::from_owned_ptr_or_err(py, self_ as _)
         }
@@ -149,7 +149,7 @@ impl<T: PyClass> PyClassShell<T> {
             crate::type_object::PyObjectSizedLayout<T::BaseType>,
     {
         unsafe {
-            let initializer = value.into_initializer()?;
+            let initializer = value.into_initializer();
             let self_ = initializer.create_shell(py)?;
             FromPyPointer::from_owned_ptr_or_err(py, self_ as _)
         }


### PR DESCRIPTION
I really like the design of `PyClassInitializer` proposed in https://github.com/PyO3/pyo3/pull/683.

However, in the form proposed, I think `IntoInitializer` is doing too much. It's handling both what is allowed to return from `#[new]` as well as allowing those types to be optionally wrapped in `PyResult`.

This means that the use of `IntoInitializer` in `Py<T>::new` can also accept `PyResult<T>` as the input, which seems too generous to me. e.g. this will compile: `Py::new(py, Ok(42))`

This also leads to other strange API usages such as

    PyResult::<i32>::Err(...).into_initializer()

I propose to simplify `IntoInitializer` to keep the conversion space smaller:
- Take the error handling out of `IntoInitializer`
- Re-use `Into` as much as possible
- Add a new `derive_utils` trait `IntoPyNewResult` to deal with the optional wrapping in `PyResult` for the macro code.

With these changes, all functionality for `#[new]` remains intact. The coupling between `IntoInitializer` and `PyResult` would be removed, making the API neater.